### PR TITLE
Use latest version instead of first one

### DIFF
--- a/etc/pyenv.d/which/whence.bash
+++ b/etc/pyenv.d/which/whence.bash
@@ -2,8 +2,8 @@ if [ -n "$PYENV_COMMAND" ] && [ ! -x "$PYENV_COMMAND_PATH" ]; then
   versions=($(pyenv-whence "${PYENV_COMMAND}" 2>/dev/null || true))
   if [ -n "${versions}" ]; then
     if [ "${#versions[@]}" -gt 1 ]; then
-      echo "pyenv-implicit: found multiple ${PYENV_COMMAND} in pyenv. Use version ${versions[0]}." 1>&2
+      echo "pyenv-implicit: found multiple ${PYENV_COMMAND} in pyenv. Use version ${versions[-1]}." 1>&2
     fi
-    PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${versions[0]}/bin/${PYENV_COMMAND}"
+    PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${versions[-1]}/bin/${PYENV_COMMAND}"
   fi
 fi

--- a/etc/pyenv.d/which/whence.bash
+++ b/etc/pyenv.d/which/whence.bash
@@ -1,6 +1,9 @@
 if [ -n "$PYENV_COMMAND" ] && [ ! -x "$PYENV_COMMAND_PATH" ]; then
   versions=($(pyenv-whence "${PYENV_COMMAND}" 2>/dev/null || true))
-  if [ "${#versions[@]}" -eq 1 ]; then
+  if [ -n "${versions}" ]; then
+    if [ "${#versions[@]}" -gt 1 ]; then
+      echo "pyenv-implicit: found multiple ${PYENV_COMMAND} in pyenv. Use version ${versions[0]}." 1>&2
+    fi
     PYENV_COMMAND_PATH="${PYENV_ROOT}/versions/${versions[0]}/bin/${PYENV_COMMAND}"
   fi
 fi


### PR DESCRIPTION
Instead of using the first version among the candidates found take the last one. Since versions are sorted alphabetically this should be the latest installed version.